### PR TITLE
`lib` is not necessary to be published?

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist",
-    "lib"
+    "dist"
   ],
   "scripts": {
     "pretest": "npm run format && npm run build",


### PR DESCRIPTION
`package.json` doesn't see `lib`